### PR TITLE
Support pre PHP 7.0 cleanly

### DIFF
--- a/src/PublicSuffixList.php
+++ b/src/PublicSuffixList.php
@@ -226,6 +226,9 @@ class PublicSuffixList
         $cacheFile = $this->getCacheFileName($url);
         if (file_exists($cacheFile)) {
             $cachedTree = file_get_contents($cacheFile);
+            if(PHP_VERSION_ID < 070000) {
+                return unserialize($cachedTree);
+            }
             return unserialize($cachedTree, array('allowed_classes' => false));
         }
         return false;


### PR DESCRIPTION
Quiets "Warning: unserialize() expects exactly 1 parameter..."